### PR TITLE
fix: 修复 JWT 算法降级(alg:none)绕过鉴权及多处 JWT 安全漏洞

### DIFF
--- a/src/main/java/com/youlai/boot/config/WebSocketConfig.java
+++ b/src/main/java/com/youlai/boot/config/WebSocketConfig.java
@@ -187,7 +187,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             throw new BadCredentialsException("Token 为空");
         }
 
-        // 解析并验证 Token
+        // 校验 Token 有效性（算法+签名+过期时间+黑名单）
+        if (!tokenManager.validateToken(token)) {
+            log.warn("⚠ 非法连接请求：Token 无效或已过期");
+            throw new BadCredentialsException("Token 无效或已过期");
+        }
+
+        // 解析 Token
         Authentication authentication;
         try {
             authentication = tokenManager.parseToken(token);

--- a/src/main/java/com/youlai/boot/security/token/JwtTokenManager.java
+++ b/src/main/java/com/youlai/boot/security/token/JwtTokenManager.java
@@ -49,6 +49,8 @@ import java.util.stream.Collectors;
 @Service
 public class JwtTokenManager implements TokenManager {
 
+    private static final String ALLOWED_ALGORITHM = "HS256";
+
     private final SecurityProperties securityProperties;
     private final RedisTemplate<String, Object> redisTemplate;
     private final byte[] secretKey;
@@ -91,6 +93,14 @@ public class JwtTokenManager implements TokenManager {
     public Authentication parseToken(String token) {
 
         JWT jwt = JWTUtil.parseToken(token);
+
+        if (!isAlgorithmAllowed(jwt)) {
+            throw new BusinessException(ResultCode.ACCESS_TOKEN_INVALID);
+        }
+        if (!jwt.setKey(secretKey).verify()) {
+            throw new BusinessException(ResultCode.ACCESS_TOKEN_INVALID);
+        }
+
         JSONObject payloads = jwt.getPayloads();
         SysUserDetails userDetails = new SysUserDetails();
         userDetails.setUserId(payloads.getLong(JwtClaimConstants.USER_ID)); // 用户ID
@@ -164,6 +174,11 @@ public class JwtTokenManager implements TokenManager {
      */
     private boolean validateToken(String token, boolean validateRefreshToken) {
         JWT jwt = JWTUtil.parseToken(token);
+
+        if (!isAlgorithmAllowed(jwt)) {
+            return false;
+        }
+
         // 检查 Token 是否有效(验签 + 是否过期)
         boolean isValid = jwt.setKey(secretKey).validate(0);
 
@@ -219,6 +234,11 @@ public class JwtTokenManager implements TokenManager {
             token = token.substring(SecurityConstants.BEARER_TOKEN_PREFIX.length());
         }
         JWT jwt = JWTUtil.parseToken(token);
+
+        if (!isAlgorithmAllowed(jwt) || !jwt.setKey(secretKey).verify()) {
+            return;
+        }
+
         JSONObject payloads = jwt.getPayloads();
         String jti = payloads.getStr(JWTPayload.JWT_ID);
         Integer expirationAt = payloads.getInt(JWTPayload.EXPIRES_AT);
@@ -398,6 +418,14 @@ public class JwtTokenManager implements TokenManager {
         payload.put(JWTPayload.JWT_ID, IdUtil.simpleUUID());
 
         return JWTUtil.createToken(payload, secretKey);
+    }
+
+    /**
+     * 校验JWT算法类型是否在允许的白名单中，防止 alg:none 等算法降级攻击
+     */
+    private boolean isAlgorithmAllowed(JWT jwt) {
+        Object algorithm = jwt.getHeader("alg");
+        return algorithm != null && ALLOWED_ALGORITHM.equals(algorithm.toString());
     }
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -87,7 +87,7 @@ security:
     access-token-time-to-live: 7200 # 访问令牌 有效期(单位：秒)，默认 2 小时，-1 表示永不过期
     refresh-token-time-to-live: 604800 # 刷新令牌有效期(单位：秒)，默认 7 天，-1 表示永不过期
     jwt:
-      secret-key: SecretKey012345678901234567890123456789012345678901234567890123456789 # JWT密钥(HS256算法至少32字符)
+      secret-key: SecretKey012345678901234567890123456789012345678901234567890123456789 # JWT密钥(HS256算法至少32字符) 【安全警告】生产环境必须更换此默认密钥，否则攻击者可直接伪造合法Token
     redis-token:
       allow-multi-login: true # 是否允许多设备登录
   # 安全白名单路径，仅跳过 AuthorizationFilter 过滤器，还是会走 Spring Security 的其他过滤器(CSRF、CORS等)


### PR DESCRIPTION
## 漏洞概述

- **漏洞类型**：JWT 安全配置缺陷 / 认证绕过 / 水平越权 / 垂直越权
- **风险等级**：严重
- **影响范围**：所有依赖 JWT 鉴权的 HTTP 接口 + WebSocket 连接

该漏洞允许攻击者通过 JWT 算法降级（`alg:none`）绕过签名校验，伪造任意用户身份，遍历所有用户隐私数据（水平越权），甚至伪造管理员角色接管后台（垂直越权）。同时 WebSocket 连接缺少 Token 校验，攻击者可使用过期/伪造 Token 建立连接。

---

## 漏洞详情

### 漏洞1：JWT 算法降级 (alg:none) 绕过签名校验 【严重】

**原因**：`JwtTokenManager.validateToken()` 中使用 `jwt.setKey(secretKey).validate(0)` 进行验签，但未校验 JWT header 中的 `alg` 字段。Hutool JWT 库在 `alg` 为 `none` 时不会拒绝该 Token，导致无签名的 Token 通过校验。

**影响**：
- 攻击者修改 JWT header 的 `alg` 为 `none`，修改 payload 中的 `userId` 为任意值，去掉签名部分，即可访问任意用户的隐私数据（手机号、姓名等）
- 由于 `userId` 通常为顺序递增的数字，攻击者可遍历所有用户数据

**复现步骤**：
1. 注册普通用户并登录，获取合法 JWT Token
2. 使用 [jwt.io](https://jwt.io) 解码 Token，将 header 中的 `alg` 由 `HS256` 改为 `none`
3. 修改 payload 中的 `userId` 为目标用户 ID
4. 将修改后的 header 和 payload 进行 Base64URL 编码，签名部分留空（Token 以 `.` 结尾）
5. 使用构造的 Token 发送请求：
```
GET /api/v1/users/me HTTP/1.1
Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJ1c2VySWQiOjEsImF1dGhvcml0aWVzIjpbIlJPTEVfQURNSU4iXX0.
```
6. 服务端返回目标用户的完整数据

### 漏洞2：WebSocket 连接不校验 Token 有效性 【严重】

**原因**：`WebSocketConfig.handleConnect()` 只调用了 `tokenManager.parseToken(token)`，未调用 `tokenManager.validateToken(token)`。

**影响**：
- 过期的 Token 仍可建立 WebSocket 连接
- 已注销用户（Token 在黑名单中）仍可建立 WebSocket 连接
- `alg:none` 伪造的 Token 可建立 WebSocket 连接

### 漏洞3：parseToken 无安全校验，可伪造任意角色 【高危】

**原因**：`parseToken()` 作为 `public` 方法，直接解析 JWT payload 并信任其中的 `userId`、`deptId`、`dataScopes`、`authorities` 等关键字段，无任何算法或签名校验。

**影响**：配合漏洞1（alg:none）或漏洞2（WebSocket 无校验），攻击者可在 payload 中伪造 `ROLE_ADMIN` 权限，实现从普通用户到管理员的垂直越权，接管整个管理后台。

### 漏洞4：invalidateToken 未验证 Token 即操作 Redis 【中危】

**原因**：`invalidateToken()` 直接解析未验证的 Token，并使用其中的 `jti` 字段调用 `revokeTokenByJti()` 向 Redis 写入黑名单数据。

**影响**：攻击者可构造包含任意 `jti` 的恶意 Token，向 Redis 写入大量黑名单 Key，造成 Redis 资源耗尽（DoS）。

---

## 修复方案

### 1. `JwtTokenManager.java`

- 新增 `ALLOWED_ALGORITHM = "HS256"` 常量和 `isAlgorithmAllowed(JWT jwt)` 方法，仅允许 HS256 算法
- `validateToken()`：在 `jwt.setKey(secretKey).validate(0)` 之前增加 `isAlgorithmAllowed()` 校验，`alg` 不是 HS256 直接返回 `false`
- `parseToken()`：增加算法 + 签名双重校验（防御纵深），即使被单独调用也能拒绝伪造 Token
- `invalidateToken()`：在解析 Token 后、操作 Redis 前增加算法 + 签名校验

### 2. `WebSocketConfig.java`

- `handleConnect()`：在 `tokenManager.parseToken(token)` 之前增加 `tokenManager.validateToken(token)` 调用，拦截过期/伪造/黑名单 Token

### 3. `application-dev.yml`

- 在默认密钥配置处添加安全警告注释，提醒生产环境必须更换默认密钥

---

## 测试计划

### 安全测试（验证漏洞已修复）

- [ ] **alg:none 攻击测试**：构造 `alg=none` 的 JWT Token，发送 HTTP 请求，验证服务端返回 401 Unauthorized（修复前返回 200）
- [ ] **伪造 ROLE_ADMIN 测试**：构造包含 `ROLE_ADMIN` 权限的 `alg=none` Token，访问管理接口，验证被拒绝
- [ ] **WebSocket 伪造 Token 测试**：使用 `alg=none` 的 Token 建立 WebSocket 连接，验证连接被拒绝
- [ ] **WebSocket 过期 Token 测试**：使用已过期的 Token 建立 WebSocket 连接，验证连接被拒绝
- [ ] **invalidateToken 恶意 Token 测试**：构造恶意 Token 调用注销接口，验证 Redis 中无新增黑名单 Key

### 功能回归测试（验证正常功能不受影响）

- [ ] **正常登录测试**：使用账号密码登录，获取 Token，验证正常返回
- [ ] **正常接口访问测试**：使用合法 Token 访问受保护接口，验证正常返回数据
- [ ] **Token 刷新测试**：使用合法 Refresh Token 刷新 Access Token，验证正常返回新 Token
- [ ] **正常注销测试**：调用注销接口，验证 Token 被正常加入黑名单
- [ ] **WebSocket 正常连接测试**：使用合法 Token 建立 WebSocket 连接，验证连接成功
